### PR TITLE
Selective Query String encoding

### DIFF
--- a/sling_test.go
+++ b/sling_test.go
@@ -502,7 +502,7 @@ func TestAddQueryStructs(t *testing.T) {
 	}
 	for _, c := range cases {
 		reqURL, _ := url.Parse(c.rawurl)
-		addQueryStructs(reqURL, c.queryStructs)
+		addQueryStructs(reqURL, c.queryStructs, true)
 		if reqURL.String() != c.expected {
 			t.Errorf("expected %s, got %s", c.expected, reqURL.String())
 		}


### PR DESCRIPTION
I ran across an issue that required I do not URL encode query string variables. This series of commits allows you to set the EncodeQueryStructs property on a Sling to specify whether or not you want to URL encode the query string variables.

EncodeQueryStructs defaults to true.