### PR TITLE
JSON body is not decoded when Content-Type: application/json is not present

### DIFF
--- a/sling.go
+++ b/sling.go
@@ -358,7 +358,7 @@ func (s *Sling) Do(req *http.Request, successV, failureV interface{}) (*http.Res
 	}
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
 	defer resp.Body.Close()
-	if strings.Contains(resp.Header.Get(contentType), jsonContentType) {
+	if successV != nil || failureV != nil {
 		err = decodeResponseJSON(resp, successV, failureV)
 	}
 	return resp, err


### PR DESCRIPTION
Thus, I think this is logical to decode JSON whether header is set or not, because user must explicitly pass successV/failureV. 

Broken test defines current behaviour, If you agree I will fix it too.