### PR TITLE
Add basic auth support: Sling.SetBasicAuth()

### DIFF
--- a/sling.go
+++ b/sling.go
@@ -2,6 +2,7 @@ package sling
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"io/ioutil"
@@ -143,6 +144,20 @@ func (s *Sling) Add(key, value string) *Sling {
 func (s *Sling) Set(key, value string) *Sling {
 	s.header.Set(key, value)
 	return s
+}
+
+// SetBasicAuth mimics http.Request.SetBasicAuth()
+// setting the basic auth headers for all requests
+// which is convenient when building API clients
+func (s *Sling) SetBasicAuth(username, password string) *Sling {
+	return s.Set("Authorization", "Basic "+basicAuth(username, password))
+}
+
+// basicAuth copied from src/net/http/client.go
+// encodes username & password to base64
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
 }
 
 // Url

--- a/sling.go
+++ b/sling.go
@@ -146,15 +146,15 @@ func (s *Sling) Set(key, value string) *Sling {
 	return s
 }
 
-// SetBasicAuth mimics http.Request.SetBasicAuth()
-// setting the basic auth headers for all requests
-// which is convenient when building API clients
+// SetBasicAuth sets the Authorization header to use HTTP Basic Authentication
+// with the provided username and password. With HTTP Basic Authentication
+// the provided username and password are not encrypted.
 func (s *Sling) SetBasicAuth(username, password string) *Sling {
 	return s.Set("Authorization", "Basic "+basicAuth(username, password))
 }
 
-// basicAuth copied from src/net/http/client.go
-// encodes username & password to base64
+// basicAuth returns the base64 encoded username:password for basic auth copied
+// from net/http.
 func basicAuth(username, password string) string {
 	auth := username + ":" + password
 	return base64.StdEncoding.EncodeToString([]byte(auth))

--- a/sling_test.go
+++ b/sling_test.go
@@ -232,6 +232,34 @@ func TestSetHeader(t *testing.T) {
 	}
 }
 
+func TestBasicAuth(t *testing.T) {
+	cases := []struct {
+		sling        *Sling
+		expectedAuth []string
+	}{
+		// basic auth: username & password
+		{New().SetBasicAuth("Aladdin", "open sesame"), []string{"Aladdin", "open sesame"}},
+		// empty username
+		{New().SetBasicAuth("", "secret"), []string{"", "secret"}},
+		// empty password
+		{New().SetBasicAuth("admin", ""), []string{"admin", ""}},
+	}
+	for _, c := range cases {
+		req, err := c.sling.Request()
+		if err != nil {
+			t.Errorf("unexpected error when building Request with .SetBasicAuth()")
+		}
+		username, password, ok := req.BasicAuth()
+		if !ok {
+			t.Errorf("basic auth missing when expected")
+		}
+		auth := []string{username, password}
+		if !reflect.DeepEqual(c.expectedAuth, auth) {
+			t.Errorf("not DeepEqual: expected %v, got %v", c.expectedAuth, auth)
+		}
+	}
+}
+
 func TestQueryStructSetter(t *testing.T) {
 	cases := []struct {
 		sling           *Sling


### PR DESCRIPTION
Sling is one of the nicest libraries I found, it's composable and elegant. However I found it frustrating that it lacked Basic Auth support which is a must have when writing API clients, so I thought I would add here.

Tried to keep it as simple as possible and follow existing conventions (allow chaining etc ...)

Let me know if you have any questions.