### PR TITLE
Add Doer interface and setter

### DIFF
--- a/sling.go
+++ b/sling.go
@@ -29,7 +29,7 @@ type Doer interface {
 // Sling is an HTTP Request builder and sender.
 type Sling struct {
 	// http Client for doing requests
-	doer Doer
+	httpClient Doer
 	// HTTP method (GET, POST, etc.)
 	method string
 	// raw url string for requests
@@ -49,7 +49,7 @@ type Sling struct {
 // New returns a new Sling with an http DefaultClient.
 func New() *Sling {
 	return &Sling{
-		doer:         http.DefaultClient,
+		httpClient:   http.DefaultClient,
 		method:       "GET",
 		header:       make(http.Header),
 		queryStructs: make([]interface{}, 0),
@@ -75,7 +75,7 @@ func (s *Sling) New() *Sling {
 		headerCopy[k] = v
 	}
 	return &Sling{
-		doer:         s.doer,
+		httpClient:   s.httpClient,
 		method:       s.method,
 		rawURL:       s.rawURL,
 		header:       headerCopy,
@@ -101,9 +101,9 @@ func (s *Sling) Client(httpClient *http.Client) *Sling {
 // If a nil client is given, the http.DefaultClient will be used.
 func (s *Sling) Doer(doer Doer) *Sling {
 	if doer == nil {
-		s.doer = http.DefaultClient
+		s.httpClient = http.DefaultClient
 	} else {
-		s.doer = doer
+		s.httpClient = doer
 	}
 	return s
 }
@@ -383,7 +383,7 @@ func (s *Sling) Receive(successV, failureV interface{}) (*http.Response, error) 
 // are JSON decoded into the value pointed to by failureV.
 // Any error sending the request or decoding the response is returned.
 func (s *Sling) Do(req *http.Request, successV, failureV interface{}) (*http.Response, error) {
-	resp, err := s.doer.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return resp, err
 	}

--- a/sling.go
+++ b/sling.go
@@ -20,7 +20,8 @@ const (
 )
 
 // Doer executes http requests.  It is implemented by *http.Client.  You can
-// wrap *http.Client with layers of Doers to form a stack of client-side middleware.
+// wrap *http.Client with layers of Doers to form a stack of client-side
+// middleware.
 type Doer interface {
 	Do(req *http.Request) (*http.Response, error)
 }
@@ -96,8 +97,8 @@ func (s *Sling) Client(httpClient *http.Client) *Sling {
 	return s.Doer(httpClient)
 }
 
-// Doer sets the doer used to execute http requests.  If nil,
-// http.DefaultClient will be used.
+// Doer sets the custom Doer implementation used to do requests.
+// If a nil client is given, the http.DefaultClient will be used.
 func (s *Sling) Doer(doer Doer) *Sling {
 	if doer == nil {
 		s.doer = http.DefaultClient

--- a/sling_test.go
+++ b/sling_test.go
@@ -39,8 +39,8 @@ var modelA = FakeModel{Text: "note", FavoriteCount: 12}
 
 func TestNew(t *testing.T) {
 	sling := New()
-	if sling.httpClient != http.DefaultClient {
-		t.Errorf("expected %v, got %v", http.DefaultClient, sling.httpClient)
+	if sling.doer != http.DefaultClient {
+		t.Errorf("expected %v, got %v", http.DefaultClient, sling.doer)
 	}
 	if sling.header == nil {
 		t.Errorf("Header map not initialized with make")
@@ -52,8 +52,8 @@ func TestNew(t *testing.T) {
 
 func TestSlingNew(t *testing.T) {
 	cases := []*Sling{
-		&Sling{httpClient: &http.Client{}, method: "GET", rawURL: "http://example.com"},
-		&Sling{httpClient: nil, method: "", rawURL: "http://example.com"},
+		&Sling{doer: &http.Client{}, method: "GET", rawURL: "http://example.com"},
+		&Sling{doer: nil, method: "", rawURL: "http://example.com"},
 		&Sling{queryStructs: make([]interface{}, 0)},
 		&Sling{queryStructs: []interface{}{paramsA}},
 		&Sling{queryStructs: []interface{}{paramsA, paramsB}},
@@ -68,8 +68,8 @@ func TestSlingNew(t *testing.T) {
 	}
 	for _, sling := range cases {
 		child := sling.New()
-		if child.httpClient != sling.httpClient {
-			t.Errorf("expected %p, got %p", sling.httpClient, child.httpClient)
+		if child.doer != sling.doer {
+			t.Errorf("expected %v, got %v", sling.doer, child.doer)
 		}
 		if child.method != sling.method {
 			t.Errorf("expected %s, got %s", sling.method, child.method)
@@ -120,8 +120,26 @@ func TestClientSetter(t *testing.T) {
 	for _, c := range cases {
 		sling := New()
 		sling.Client(c.input)
-		if sling.httpClient != c.expected {
-			t.Errorf("expected %v, got %v", c.expected, sling.httpClient)
+		if sling.doer != c.expected {
+			t.Errorf("input %v, expected %v, got %v", c.input, c.expected, sling.doer)
+		}
+	}
+}
+
+func TestDoerSetter(t *testing.T) {
+	developerClient := &http.Client{}
+	cases := []struct {
+		input    Doer
+		expected Doer
+	}{
+		{nil, http.DefaultClient},
+		{developerClient, developerClient},
+	}
+	for _, c := range cases {
+		sling := New()
+		sling.Doer(c.input)
+		if sling.doer != c.expected {
+			t.Errorf("input %v, expected %v, got %v", c.input, c.expected, sling.doer)
 		}
 	}
 }

--- a/sling_test.go
+++ b/sling_test.go
@@ -39,8 +39,8 @@ var modelA = FakeModel{Text: "note", FavoriteCount: 12}
 
 func TestNew(t *testing.T) {
 	sling := New()
-	if sling.doer != http.DefaultClient {
-		t.Errorf("expected %v, got %v", http.DefaultClient, sling.doer)
+	if sling.httpClient != http.DefaultClient {
+		t.Errorf("expected %v, got %v", http.DefaultClient, sling.httpClient)
 	}
 	if sling.header == nil {
 		t.Errorf("Header map not initialized with make")
@@ -52,8 +52,8 @@ func TestNew(t *testing.T) {
 
 func TestSlingNew(t *testing.T) {
 	cases := []*Sling{
-		&Sling{doer: &http.Client{}, method: "GET", rawURL: "http://example.com"},
-		&Sling{doer: nil, method: "", rawURL: "http://example.com"},
+		&Sling{httpClient: &http.Client{}, method: "GET", rawURL: "http://example.com"},
+		&Sling{httpClient: nil, method: "", rawURL: "http://example.com"},
 		&Sling{queryStructs: make([]interface{}, 0)},
 		&Sling{queryStructs: []interface{}{paramsA}},
 		&Sling{queryStructs: []interface{}{paramsA, paramsB}},
@@ -68,8 +68,8 @@ func TestSlingNew(t *testing.T) {
 	}
 	for _, sling := range cases {
 		child := sling.New()
-		if child.doer != sling.doer {
-			t.Errorf("expected %v, got %v", sling.doer, child.doer)
+		if child.httpClient != sling.httpClient {
+			t.Errorf("expected %v, got %v", sling.httpClient, child.httpClient)
 		}
 		if child.method != sling.method {
 			t.Errorf("expected %s, got %s", sling.method, child.method)
@@ -120,8 +120,8 @@ func TestClientSetter(t *testing.T) {
 	for _, c := range cases {
 		sling := New()
 		sling.Client(c.input)
-		if sling.doer != c.expected {
-			t.Errorf("input %v, expected %v, got %v", c.input, c.expected, sling.doer)
+		if sling.httpClient != c.expected {
+			t.Errorf("input %v, expected %v, got %v", c.input, c.expected, sling.httpClient)
 		}
 	}
 }
@@ -138,8 +138,8 @@ func TestDoerSetter(t *testing.T) {
 	for _, c := range cases {
 		sling := New()
 		sling.Doer(c.input)
-		if sling.doer != c.expected {
-			t.Errorf("input %v, expected %v, got %v", c.input, c.expected, sling.doer)
+		if sling.httpClient != c.expected {
+			t.Errorf("input %v, expected %v, got %v", c.input, c.expected, sling.httpClient)
 		}
 	}
 }


### PR DESCRIPTION
Replaced use of *http.Client with interface Doer.  Allows use of client-side middleware by wrapping *http.Client before passing to Sling.