### PR TITLE
Decode JSON success/failure regardless of Content-Type

### DIFF
--- a/sling.go
+++ b/sling.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	goquery "github.com/google/go-querystring/query"
 )
@@ -352,7 +351,7 @@ func (s *Sling) Do(req *http.Request, successV, failureV interface{}) (*http.Res
 	}
 	// when err is nil, resp contains a non-nil resp.Body which must be closed
 	defer resp.Body.Close()
-	if strings.Contains(resp.Header.Get(contentType), jsonContentType) {
+	if successV != nil || failureV != nil {
 		err = decodeResponseJSON(resp, successV, failureV)
 	}
 	return resp, err

--- a/sling_test.go
+++ b/sling_test.go
@@ -368,7 +368,6 @@ func TestBodyFormSetter(t *testing.T) {
 			t.Errorf("did not expect a Content-Type header, got %s", sling.header.Get(contentType))
 		}
 	}
-
 }
 
 func TestBodySetter(t *testing.T) {
@@ -712,26 +711,6 @@ func TestDo_onFailureWithNilValue(t *testing.T) {
 	expected := &FakeModel{}
 	if !reflect.DeepEqual(expected, model) {
 		t.Errorf("successV should not be populated, exepcted %v, got %v", expected, model)
-	}
-}
-
-func TestDo_skipDecodingIfContentTypeWrong(t *testing.T) {
-	client, mux, server := testServer()
-	defer server.Close()
-	mux.HandleFunc("/success", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/html")
-		fmt.Fprintf(w, `{"text": "Some text", "favorite_count": 24}`)
-	})
-
-	sling := New().Client(client)
-	req, _ := http.NewRequest("GET", "http://example.com/success", nil)
-
-	model := new(FakeModel)
-	sling.Do(req, model, nil)
-
-	expectedModel := &FakeModel{}
-	if !reflect.DeepEqual(expectedModel, model) {
-		t.Errorf("decoding should have been skipped, Content-Type was incorrect")
 	}
 }
 

--- a/test
+++ b/test
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
- set -e
+set -e
 
 PKGS=$(go list ./... | grep -v /examples)
 FORMATTABLE="$(find . -maxdepth 1 -type d)"


### PR DESCRIPTION
* Allow JSON responses to be received and decoded from APIs with unconstrained or even incorrect Content-Type headers
* Enough folks ask about this, there is a clear preference that Sling JSON decode responses (regardless of Content-Type). Rather than writing custom response decoders to handle those edges.

rel: #14
Closes #24 