### PR TITLE
Add Context support.

### DIFF
--- a/sling.go
+++ b/sling.go
@@ -1,11 +1,14 @@
 package sling
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	goquery "github.com/google/go-querystring/query"
 )
@@ -37,6 +40,10 @@ type Sling struct {
 	queryStructs []interface{}
 	// body provider
 	bodyProvider BodyProvider
+	// context for a request
+	ctx context.Context
+	// to be called on Do to avoid context leaks
+	cancel context.CancelFunc
 }
 
 // New returns a new Sling with an http DefaultClient.
@@ -48,6 +55,8 @@ func New() *Sling {
 		queryStructs: make([]interface{}, 0),
 	}
 }
+
+var errContextReused = errors.New("(*Sling).New: cannot reuse context from base Sling")
 
 // New returns a copy of a Sling for creating a new Sling with properties
 // from a parent Sling. For example,
@@ -61,7 +70,13 @@ func New() *Sling {
 //
 // Note that query and body values are copied so if pointer values are used,
 // mutating the original value will mutate the value within the child Sling.
+//
+// Because contexts can't be reused, New panics if a non-nil context was
+// set on the base Sling.
 func (s *Sling) New() *Sling {
+	if s.ctx != nil {
+		panic(errContextReused)
+	}
 	// copy Headers pairs into new Header map
 	headerCopy := make(http.Header)
 	for k, v := range s.header {
@@ -250,6 +265,33 @@ func (s *Sling) BodyForm(bodyForm interface{}) *Sling {
 	return s.BodyProvider(formBodyProvider{payload: bodyForm})
 }
 
+// Context sets the context for the request.
+//
+// Because contexts cannot be reused, a Sling with a context also cannot be
+// reused, nor used as a base for other Slings with New.
+func (s *Sling) Context(ctx context.Context) *Sling {
+	s.ctx = ctx
+	return s
+}
+
+// Timeout is a convenience method for calling Context with a context
+// returned by WithTimeout on top of the Background context.
+//
+// Its cancel function is called when Do, or its shorthands Receive and
+// ReceiveSuccess, are called and return. If there's a chance you won't be
+// calling those, use the Context method instead and make sure you call the
+// cancel function in all cases. Otherwise, you'll have a context leak.
+//
+// Because contexts cannot be reused, a Sling with a context also cannot be
+// reused, nor used as a base for other Slings with New.
+func (s *Sling) Timeout(d time.Duration) *Sling {
+	ctx, cancel := withTimeout(context.Background(), d)
+	s.cancel = cancel
+	return s.Context(ctx)
+}
+
+var withTimeout = context.WithTimeout
+
 // Requests
 
 // Request returns a new http.Request created with the Sling properties.
@@ -276,6 +318,9 @@ func (s *Sling) Request() (*http.Request, error) {
 	req, err := http.NewRequest(s.method, reqURL.String(), body)
 	if err != nil {
 		return nil, err
+	}
+	if s.ctx != nil {
+		req = req.WithContext(s.ctx)
 	}
 	addHeaders(req, s.header)
 	return req, err
@@ -345,6 +390,10 @@ func (s *Sling) Receive(successV, failureV interface{}) (*http.Response, error) 
 // are JSON decoded into the value pointed to by failureV.
 // Any error sending the request or decoding the response is returned.
 func (s *Sling) Do(req *http.Request, successV, failureV interface{}) (*http.Response, error) {
+	if s.cancel != nil {
+		defer s.cancel()
+	}
+
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		return resp, err

--- a/sling_test.go
+++ b/sling_test.go
@@ -1,7 +1,9 @@
 package sling
 
 import (
+	"bufio"
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +15,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 )
 
 type FakeParams struct {
@@ -565,6 +568,115 @@ func TestRequest_headers(t *testing.T) {
 			t.Errorf("not DeepEqual: expected %v, got %v", c.expectedHeader, headerMap)
 		}
 	}
+}
+
+func TestRequest_context(t *testing.T) {
+	type key string
+	ctx := context.WithValue(context.Background(), key("foo"), "bar")
+	sling := New().Context(ctx)
+	req, _ := sling.Request()
+	if req.Context().Value(key("foo")) != "bar" {
+		t.Errorf("Context method didn't set the context on the resulting Request")
+	}
+}
+
+func TestRequest_timeout(t *testing.T) {
+	oldWithTimeout := withTimeout
+	defer func() { withTimeout = oldWithTimeout }()
+
+	timeout := 13 * time.Second
+
+	type key string
+
+	var calledCancel bool
+	withTimeout = func(ctx context.Context, d time.Duration) (context.Context, context.CancelFunc) {
+		t.Helper()
+
+		if d != timeout {
+			t.Errorf("expected withTimeout to be called with %v, got %v", timeout, d)
+		}
+
+		return context.WithValue(ctx, key("foo"), "bar"), func() {
+			calledCancel = true
+		}
+	}
+
+	sling := New().Timeout(timeout)
+	req, _ := sling.Request()
+	if req.Context().Value(key("foo")) != "bar" {
+		t.Errorf("Context method didn't set the context on the resulting Request")
+	}
+
+	for _, testCase := range []struct {
+		name string
+		doer doerFunc
+	}{
+		{
+			"success",
+			func(req *http.Request) (*http.Response, error) {
+				return testResponse(400, ""), nil
+			},
+		},
+		{
+			"error",
+			func(req *http.Request) (*http.Response, error) {
+				return nil, errors.New("test")
+			},
+		},
+		{
+			"204",
+			func(req *http.Request) (*http.Response, error) {
+				return testResponse(204, ""), nil
+			},
+		},
+	} {
+		t.Run("called cancel on "+testCase.name, func(t *testing.T) {
+			calledCancel = false
+			sling.Doer(doerFunc(testCase.doer)).Do(req, nil, nil)
+			if !calledCancel {
+				t.Error("cancel wasn't called")
+			}
+		})
+	}
+}
+
+func TestRequest_reused_context(t *testing.T) {
+	var err error
+
+	func() {
+		defer func() {
+			err = recover().(error)
+		}()
+		New().Context(context.Background()).New()
+	}()
+
+	if errContextReused != err {
+		t.Errorf("expected panic with error %v, got %v", errContextReused, err)
+	}
+}
+
+type doerFunc func(req *http.Request) (*http.Response, error)
+
+func (f doerFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func testResponse(status int, body string) *http.Response {
+	req, _ := http.NewRequest("GET", "http://example.com", nil)
+
+	header := fmt.Sprintf(`HTTP/1.1 %d Ignored
+Connection: close
+Content-Type: text/plain
+Content-Length: %d
+
+`, status, len(body))
+	header = strings.Replace(header, "\n", "\r\n", -1)
+
+	resp, err := http.ReadResponse(bufio.NewReader(strings.NewReader(header+body)), req)
+	if err != nil {
+		panic(err)
+	}
+	return resp
 }
 
 func TestAddQueryStructs(t *testing.T) {


### PR DESCRIPTION
Contexts are increasingly commonplace in the Go ecosystem, and it makes
sense that a library meant to wrap the standard “net/http”.Request
supports them without forcing the low-level Request and Do methods on
you.

Also, added Timeout as a convenience.