### PR TITLE
[FEATURE] Full HTTP verb support as per RFC 7231 and RFC 5789

### DIFF
--- a/sling.go
+++ b/sling.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	goquery "github.com/google/go-querystring/query"
 )
@@ -135,6 +136,31 @@ func (s *Sling) Patch(pathURL string) *Sling {
 func (s *Sling) Delete(pathURL string) *Sling {
 	s.method = "DELETE"
 	return s.Path(pathURL)
+}
+
+// Options sets the Sling method to OPTIONS and sets the given pathURL.
+func (s *Sling) Options(pathURL string) *Sling {
+	s.method = "OPTIONS"
+	return s.Path(pathURL)
+}
+
+// Trace sets the Sling method to TRACE and sets the given pathURL.
+func (s *Sling) Trace(pathURL string) *Sling {
+	s.method = "TRACE"
+	return s.Path(pathURL)
+}
+
+// Connect sets the Sling method to CONNECT and sets the given pathURL.
+func (s *Sling) Connect(pathURL string) *Sling {
+	s.method = "CONNECT"
+	return s.Path(pathURL)
+}
+
+// Method sets the Sling method to the provided value; it does not affect
+// the Sling path.
+func (s *Sling) Method(method string) *Sling {
+	s.method = strings.ToUpper(strings.TrimSpace(method))
+	return s
 }
 
 // Header

--- a/sling_test.go
+++ b/sling_test.go
@@ -196,6 +196,10 @@ func TestMethodSetters(t *testing.T) {
 		{New().Put("http://a.io"), "PUT"},
 		{New().Patch("http://a.io"), "PATCH"},
 		{New().Delete("http://a.io"), "DELETE"},
+		{New().Options("http://a.io"), "OPTIONS"},
+		{New().Trace("http://a.io"), "TRACE"},
+		{New().Connect("http://a.io"), "CONNECT"},
+		{New().Method("wHaTeVeR"), "WHATEVER"},
 	}
 	for _, c := range cases {
 		if c.sling.method != c.expectedMethod {


### PR DESCRIPTION
RFC 7231 section 4 specifies HTTP verbs as GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE.

This pull request addresses the lack of OPTIONS, CONNECT and TRACE and of the possibility to set custom verbs in a Sling. The additional verbs may be useful for general purpose HTTP requests and for automatic discovery of allowed methods in RESTful APIs (OPTIONS). 
The pull request also contains a generic Method() function to provide support for arbitrary HTTP verbs; this is allowed by the standard although somewhat discouraged: "The set of common methods for HTTP/1.1 is defined below. Although this set can be expanded, additional methods cannot be assumed to share the same semantics for separately extended clients and servers."
As an example WebDAV has its extensions to the base set of verbs.

Relevant tests are modified to test code changes.