### PR TITLE
Introduce response decoder interface

### DIFF
--- a/response.go
+++ b/response.go
@@ -1,0 +1,22 @@
+package sling
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ResponseDecoder decodes http responses into struct values.
+// Decode decodes the response into the value pointed to by v.
+type ResponseDecoder interface {
+	Decode(resp *http.Response, v interface{}) error
+}
+
+// jsonDecoder decodes http response JSON into a JSON-tagged struct value.
+type jsonDecoder struct {
+}
+
+// Decode the Response Body into the value pointed to by v.
+// Caller must provide a non-nil v and close the resp.Body.
+func (d jsonDecoder) Decode(resp *http.Response, v interface{}) error {
+	return json.NewDecoder(resp.Body).Decode(v)
+}

--- a/sling.go
+++ b/sling.go
@@ -2,7 +2,6 @@ package sling
 
 import (
 	"encoding/base64"
-	"encoding/json"
 	"io"
 	"net/http"
 	"net/url"
@@ -37,15 +36,18 @@ type Sling struct {
 	queryStructs []interface{}
 	// body provider
 	bodyProvider BodyProvider
+	// response decoder
+	responseDecoder ResponseDecoder
 }
 
 // New returns a new Sling with an http DefaultClient.
 func New() *Sling {
 	return &Sling{
-		httpClient:   http.DefaultClient,
-		method:       "GET",
-		header:       make(http.Header),
-		queryStructs: make([]interface{}, 0),
+		httpClient:      http.DefaultClient,
+		method:          "GET",
+		header:          make(http.Header),
+		queryStructs:    make([]interface{}, 0),
+		responseDecoder: jsonDecoder{},
 	}
 }
 
@@ -68,12 +70,13 @@ func (s *Sling) New() *Sling {
 		headerCopy[k] = v
 	}
 	return &Sling{
-		httpClient:   s.httpClient,
-		method:       s.method,
-		rawURL:       s.rawURL,
-		header:       headerCopy,
-		queryStructs: append([]interface{}{}, s.queryStructs...),
-		bodyProvider: s.bodyProvider,
+		httpClient:      s.httpClient,
+		method:          s.method,
+		rawURL:          s.rawURL,
+		header:          headerCopy,
+		queryStructs:    append([]interface{}{}, s.queryStructs...),
+		bodyProvider:    s.bodyProvider,
+		responseDecoder: s.responseDecoder,
 	}
 }
 
@@ -336,6 +339,15 @@ func addHeaders(req *http.Request, header http.Header) {
 
 // Sending
 
+// ResponseDecoder sets the Sling's response decoder.
+func (s *Sling) ResponseDecoder(decoder ResponseDecoder) *Sling {
+	if decoder == nil {
+		return s
+	}
+	s.responseDecoder = decoder
+	return s
+}
+
 // ReceiveSuccess creates a new HTTP request and returns the response. Success
 // responses (2XX) are JSON decoded into the value pointed to by successV.
 // Any error creating the request, sending it, or decoding a 2XX response
@@ -377,7 +389,7 @@ func (s *Sling) Do(req *http.Request, successV, failureV interface{}) (*http.Res
 
 	// Decode from json
 	if successV != nil || failureV != nil {
-		err = decodeResponseJSON(resp, successV, failureV)
+		err = decodeResponse(resp, s.responseDecoder, successV, failureV)
 	}
 	return resp, err
 }
@@ -387,22 +399,15 @@ func (s *Sling) Do(req *http.Request, successV, failureV interface{}) (*http.Res
 // otherwise. If the successV or failureV argument to decode into is nil,
 // decoding is skipped.
 // Caller is responsible for closing the resp.Body.
-func decodeResponseJSON(resp *http.Response, successV, failureV interface{}) error {
+func decodeResponse(resp *http.Response, decoder ResponseDecoder, successV, failureV interface{}) error {
 	if code := resp.StatusCode; 200 <= code && code <= 299 {
 		if successV != nil {
-			return decodeResponseBodyJSON(resp, successV)
+			return decoder.Decode(resp, successV)
 		}
 	} else {
 		if failureV != nil {
-			return decodeResponseBodyJSON(resp, failureV)
+			return decoder.Decode(resp, failureV)
 		}
 	}
 	return nil
-}
-
-// decodeResponseBodyJSON JSON decodes a Response Body into the value pointed
-// to by v.
-// Caller must provide a non-nil v and close the resp.Body.
-func decodeResponseBodyJSON(resp *http.Response, v interface{}) error {
-	return json.NewDecoder(resp.Body).Decode(v)
 }


### PR DESCRIPTION
I use Sling to get data from JSON APIs, soon I will have the use case to receive data from XML APIs, too. Hence I suggest a way that allows decoding responses from arbitrary sources:

- Introduce a  `ResponseDecoder` interface that abstracts away the actual decoding
- Provide a default `jsonDecoder` that does what the library is doing at the moment: decoding from JSON (keep bc)
- I also added a new test case, not sure if this is sufficient.
- Documentation is missing for the new feature, I need to add this.

Is there a chance of getting this merged?