### PR TITLE
Extend xml support

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,42 @@ fmt.Println(issues, githubError, resp, err)
 
 Pass a nil `successV` or `failureV` argument to skip JSON decoding into that value.
 
+#### WithXMLResponse
+
+By default sling expected JSON response from server, but you can switch it to XML response.  
+Define an XML struct to receive response and use verb WithXMLResponse to tell Sling use xml decoder.
+
+```go
+// Github Issue (abbreviated)
+type Issue struct {
+    Title  string `xml:"title"`
+    Body   string `xml:"body"`
+}
+```
+
+```go
+issues := new([]Issue)
+resp, err := githubBase.New().Get(path).WithXMLResponse().ReceiveSuccess(issues)
+fmt.Println(issues, resp, err)
+```
+
+#### WithJSONResponse
+
+For symmetry there is WithJSONResponse method, that allows to switch back to JSON response.
+
+#### ResponseDecoder
+
+If API have some other response type, it's possible to add custom response decoder with method ResponseDecoder.  
+Decoder should follow ResponseDecoder interface.
+
+```go
+// ResponseDecoder decodes http responses into struct values.
+type ResponseDecoder interface {
+	// Decode decodes the response into the value pointed to by v.
+	Decode(resp *http.Response, v interface{}) error
+}
+```
+
 ### Modify a Request
 
 Sling provides the raw http.Request so modifications can be made using standard net/http features. For example, in Go 1.7+ , add HTTP tracing to a request with a context:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Slings store HTTP Request properties to simplify sending requests and decoding r
 * Add or Set Request Headers
 * Base/Path: Extend a Sling for different endpoints
 * Encode structs into URL query parameters
-* Encode a form or JSON into the Request Body
+* Encode a form, JSON or XML into the Request Body
 * Receive JSON success or failure responses
 
 ## Install
@@ -116,6 +116,33 @@ req, err := githubBase.New().Post(path).BodyJSON(body).Request()
 ```
 
 Requests will include an `application/json` Content-Type header.
+
+#### XML Body
+
+Define [XML tagged structs](https://golang.org/pkg/encoding/xml/). Use `BodyXML` to XML encode a struct as the Body on requests.
+
+```go
+type IssueRequest struct {
+    Title     string   `xml:"title,omitempty"`
+    Body      string   `xml:"body,omitempty"`
+    Assignee  string   `xml:"assignee,omitempty"`
+    Milestone int      `xml:"milestone,omitempty"`
+    Labels    []string `xml:"labels,omitempty"`
+}
+```
+
+```go
+githubBase := sling.New().Base("https://api.github.com/").Client(httpClient)
+path := fmt.Sprintf("repos/%s/%s/issues", owner, repo)
+
+body := &IssueRequest{
+    Title: "Test title",
+    Body:  "Some issue",
+}
+req, err := githubBase.New().Post(path).BodyXML(body).Request()
+```
+
+Requests will include an `application/xml` Content-Type header.
 
 #### Form Body
 

--- a/body.go
+++ b/body.go
@@ -3,6 +3,7 @@ package sling
 import (
 	"bytes"
 	"encoding/json"
+	"encoding/xml"
 	"io"
 	"strings"
 
@@ -65,4 +66,23 @@ func (p formBodyProvider) Body() (io.Reader, error) {
 		return nil, err
 	}
 	return strings.NewReader(values.Encode()), nil
+}
+
+// xmlBodyProvider encodes a XML tagged struct value as a Body for requests.
+// See https://golang.org/pkg/encoding/xml/#MarshalIndent for details.
+type xmlBodyProvider struct {
+	payload interface{}
+}
+
+func (p xmlBodyProvider) ContentType() string {
+	return xmlContentType
+}
+
+func (p xmlBodyProvider) Body() (io.Reader, error) {
+	buf := &bytes.Buffer{}
+	err := xml.NewEncoder(buf).Encode(p.payload)
+	if err != nil {
+		return nil, err
+	}
+	return buf, nil
 }

--- a/response.go
+++ b/response.go
@@ -2,6 +2,7 @@ package sling
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"net/http"
 )
 
@@ -11,12 +12,21 @@ type ResponseDecoder interface {
 	Decode(resp *http.Response, v interface{}) error
 }
 
-// jsonDecoder decodes http response JSON into a JSON-tagged struct value.
-type jsonDecoder struct {
+// jsonResponseDecoder decodes http response JSON into a JSON-tagged struct value.
+type jsonResponseDecoder struct {
 }
 
 // Decode decodes the Response Body into the value pointed to by v.
 // Caller must provide a non-nil v and close the resp.Body.
-func (d jsonDecoder) Decode(resp *http.Response, v interface{}) error {
+func (d jsonResponseDecoder) Decode(resp *http.Response, v interface{}) error {
 	return json.NewDecoder(resp.Body).Decode(v)
+}
+
+// xmlDecoder decodes http response XML into a XML-tagged struct value.
+type xmlResponseDecoder struct{}
+
+// Decode decodes the Response Body into the value pointed to by v.
+// Caller must provide a non-nil v and close the resp.Body.
+func (d xmlResponseDecoder) Decode(resp *http.Response, v interface{}) error {
+	return xml.NewDecoder(resp.Body).Decode(v)
 }

--- a/sling.go
+++ b/sling.go
@@ -13,6 +13,7 @@ const (
 	contentType     = "Content-Type"
 	jsonContentType = "application/json"
 	formContentType = "application/x-www-form-urlencoded"
+	xmlContentType  = "application/xml"
 )
 
 // Doer executes http requests.  It is implemented by *http.Client.  You can
@@ -269,6 +270,17 @@ func (s *Sling) BodyForm(bodyForm interface{}) *Sling {
 		return s
 	}
 	return s.BodyProvider(formBodyProvider{payload: bodyForm})
+}
+
+// BodyXML sets the Sling's bodyXML. The value pointed to by the bodyXML
+// will be XML encoded as the Body on new requests (see Request()).
+// The bodyXML argument should be a pointer to a XML tagged struct. See
+// https://golang.org/pkg/encoding/xml/#MarshalIndent for details.
+func (s *Sling) BodyXML(bodyXML interface{}) *Sling {
+	if bodyXML == nil {
+		return s
+	}
+	return s.BodyProvider(xmlBodyProvider{payload: bodyXML})
 }
 
 // Requests

--- a/sling.go
+++ b/sling.go
@@ -48,7 +48,7 @@ func New() *Sling {
 		method:          "GET",
 		header:          make(http.Header),
 		queryStructs:    make([]interface{}, 0),
-		responseDecoder: jsonDecoder{},
+		responseDecoder: jsonResponseDecoder{},
 	}
 }
 
@@ -358,6 +358,16 @@ func (s *Sling) ResponseDecoder(decoder ResponseDecoder) *Sling {
 	}
 	s.responseDecoder = decoder
 	return s
+}
+
+// WithXMLResponse sets xml decoder for response.
+func (s *Sling) WithXMLResponse() *Sling {
+	return s.ResponseDecoder(xmlResponseDecoder{})
+}
+
+// WithJSONResponse sets json decoder for response.
+func (s *Sling) WithJSONResponse() *Sling {
+	return s.ResponseDecoder(jsonResponseDecoder{})
 }
 
 // ReceiveSuccess creates a new HTTP request and returns the response. Success


### PR DESCRIPTION
Hi!
Sling is a very nice api client builder and I like it a lot.
But it would be nice to handle request/response in xml form too.
I saw patch from @maxbeutel with ResponseDecoder and appreciate it.
I suggest to extend it and add WithXMLResponse() method that will switch Sling to handle xml response
and add BodyXML() method to send xml requests.