### PR TITLE
Fixes and additions

### DIFF
--- a/response.go
+++ b/response.go
@@ -2,6 +2,8 @@ package sling
 
 import (
 	"encoding/json"
+	"errors"
+	"io/ioutil"
 	"net/http"
 )
 
@@ -19,4 +21,20 @@ type jsonDecoder struct {
 // Caller must provide a non-nil v and close the resp.Body.
 func (d jsonDecoder) Decode(resp *http.Response, v interface{}) error {
 	return json.NewDecoder(resp.Body).Decode(v)
+}
+
+// byteDecoder decodes http response into a byte slice.
+type byteDecoder struct {
+}
+
+// Decode decodes the Response Body into a byte slice.
+// Caller must provide a non-nil v and close the resp.Body.
+func (d byteDecoder) Decode(resp *http.Response, v interface{}) error {
+	vBytes, ok := v.(*[]byte)
+	if !ok {
+		return errors.New("bad v type, must be *[]byte")
+	}
+	bytes, err := ioutil.ReadAll(resp.Body)
+	*vBytes = bytes
+	return err
 }

--- a/sling.go
+++ b/sling.go
@@ -358,6 +358,13 @@ func (s *Sling) ResponseDecoder(decoder ResponseDecoder) *Sling {
 	return s
 }
 
+// ByteResponse sets Sling's response decoder to byteDecoder.
+// You must pass a *[]byte to the Receive method.
+func (s *Sling) ByteResponse() *Sling {
+	s.responseDecoder = byteDecoder{}
+	return s
+}
+
 // ReceiveSuccess creates a new HTTP request and returns the response. Success
 // responses (2XX) are JSON decoded into the value pointed to by successV.
 // Any error creating the request, sending it, or decoding a 2XX response

--- a/sling.go
+++ b/sling.go
@@ -320,6 +320,11 @@ func (s *Sling) Request() (*http.Request, error) {
 // encode them to url.Values and format them onto the url.RawQuery. Any
 // query parsing or encoding errors are returned.
 func addQueryStructs(reqURL *url.URL, queryStructs []interface{}) error {
+	// don't change query if not necessary
+	if len(queryStructs) < 1 {
+		return nil
+	}
+
 	urlValues, err := url.ParseQuery(reqURL.RawQuery)
 	if err != nil {
 		return err

--- a/sling.go
+++ b/sling.go
@@ -175,6 +175,15 @@ func (s *Sling) Set(key, value string) *Sling {
 	return s
 }
 
+// SetMany sets multiple headers at once, replacing existing values
+// associated with each key. Header keys are canonicalized.
+func (s *Sling) SetMany(headers map[string]string) *Sling {
+	for key, value := range headers {
+		s.header.Set(key, value)
+	}
+	return s
+}
+
 // SetBasicAuth sets the Authorization header to use HTTP Basic Authentication
 // with the provided username and password. With HTTP Basic Authentication
 // the provided username and password are not encrypted.

--- a/sling_test.go
+++ b/sling_test.go
@@ -589,6 +589,8 @@ func TestAddQueryStructs(t *testing.T) {
 		expected     string
 	}{
 		{"http://a.io", []interface{}{}, "http://a.io"},
+		{"http://a.io/?test", []interface{}{}, "http://a.io/?test"},
+		{"http://a.io/?test=", []interface{}{}, "http://a.io/?test="},
 		{"http://a.io", []interface{}{paramsA}, "http://a.io?limit=30"},
 		{"http://a.io", []interface{}{paramsA, paramsA}, "http://a.io?limit=30&limit=30"},
 		{"http://a.io", []interface{}{paramsA, paramsB}, "http://a.io?count=25&kind_name=recent&limit=30"},

--- a/sling_test.go
+++ b/sling_test.go
@@ -922,6 +922,28 @@ func TestReceive_errorCreatingRequest(t *testing.T) {
 	}
 }
 
+func TestReceiveBody(t *testing.T) {
+	client, mux, server := testServer()
+	defer server.Close()
+	mux.HandleFunc("/foo/read", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{"text": "Some text", "favorite_count": 24}`)
+	})
+
+	endpoint := New().Client(client).Base("http://example.com/").Path("foo/").Get("read")
+	resp, err := endpoint.New().ReceiveBody()
+
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected %d, got %d", 200, resp.StatusCode)
+	}
+	if err := resp.Body.Close(); err != nil {
+		t.Errorf("could not close body, it was probably already closed: %v", err)
+	}
+}
+
 func TestReuseTcpConnections(t *testing.T) {
 	var connCount int32
 

--- a/sling_test.go
+++ b/sling_test.go
@@ -241,6 +241,28 @@ func TestAddHeader(t *testing.T) {
 	}
 }
 
+func TestAddCookie(t *testing.T) {
+	cases := []struct {
+		sling           *Sling
+		expectedCookies []*http.Cookie
+	}{
+		{New().AddCookie(&http.Cookie{Name: "test", Domain: "http://example.com/"}),
+			[]*http.Cookie{{Name: "test", Domain: "http://example.com/"}},
+		},
+		// existing cookies should be appended
+		{New().AddCookie(&http.Cookie{Name: "test", Domain: "http://example.com/"}).
+			AddCookie(&http.Cookie{Name: "test2", Domain: "http://example2.com/"}),
+			[]*http.Cookie{{Name: "test", Domain: "http://example.com/"},
+				{Name: "test2", Domain: "http://example2.com/"}},
+		},
+	}
+	for _, c := range cases {
+		if !reflect.DeepEqual(c.expectedCookies, c.sling.cookies) {
+			t.Errorf("not DeepEqual: expected %v, got %v", c.expectedCookies, c.sling.cookies)
+		}
+	}
+}
+
 func TestSetHeader(t *testing.T) {
 	cases := []struct {
 		sling          *Sling

--- a/sling_test.go
+++ b/sling_test.go
@@ -252,6 +252,7 @@ func TestSetHeader(t *testing.T) {
 		// Set should replace values received by copying parent Slings
 		{New().Set("A", "B").Add("a", "c").New(), map[string][]string{"A": []string{"B", "c"}}},
 		{New().Add("A", "B").New().Set("a", "c"), map[string][]string{"A": []string{"c"}}},
+		{New().SetMany(map[string]string{"a": "b", "c": "d"}), map[string][]string{"A": {"b"}, "C": {"d"}}},
 	}
 	for _, c := range cases {
 		// type conversion from Header to alias'd map for deep equality comparison

--- a/sling_test.go
+++ b/sling_test.go
@@ -795,6 +795,34 @@ func TestReceive_success_nonDefaultDecoder(t *testing.T) {
 	}
 }
 
+func TestReceive_success_byteDecoder(t *testing.T) {
+	client, mux, server := testServer()
+	defer server.Close()
+	mux.HandleFunc("/foo/read", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte{0x1, 0x2, 0x3})
+	})
+
+	endpoint := New().Client(client).Base("http://example.com/").Path("foo/").Get("read")
+	model := make([]byte, 0)
+	apiError := make([]byte, 0)
+	resp, err := endpoint.New().ByteResponse().Receive(&model, &apiError)
+
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected %d, got %d", 200, resp.StatusCode)
+	}
+	expectedModel := []byte{0x1, 0x2, 0x3}
+	if !reflect.DeepEqual(expectedModel, model) {
+		t.Errorf("expected %v, got %v", expectedModel, model)
+	}
+	expectedAPIError := []byte{}
+	if !reflect.DeepEqual(expectedAPIError, apiError) {
+		t.Errorf("failureV should be zero valued, exepcted %v, got %v", expectedAPIError, apiError)
+	}
+}
+
 func TestReceive_success(t *testing.T) {
 	client, mux, server := testServer()
 	defer server.Close()


### PR DESCRIPTION
Before I begin, I would like to thank you so much for creating this library. Its ergonomic design made it possible for me to reduce a codebase by about 20% and massively simplify it.

In the course of usage, I identified a few repeating patterns and slight issues, which I fixed. I really hope you could merge them all, but if there's something you do not like or agree with, I would love to discuss.

There is just one potentially breaking change:

- __Don't change query if not necessary__

I was working with a 3rd-party API that strictly expected a request in the form of `/?test`, without the trailing equals (`/?test=`). Currently, sling passes every request through `url.Encode`, which will "fix" the incorrect query. This, unfortunately, made it impossible for me to use the API. The fix I propose is simple - don't touch the query if you don't have to. This is how `http.Request` works anyway.
