### PR TITLE
build: bump go-querystring v1.1.0, go v1.16 in github action

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,5 @@
 name: test
+
 on:
   push:
     branches:
@@ -6,6 +7,7 @@ on:
   pull_request:
     branches:
       - master
+
 jobs:
   build:
     name: go
@@ -13,18 +15,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.13', '1.14', '1.15']
+        go: ["~1.15", "~1.16"]
     steps:
       - name: setup
         uses: actions/setup-go@v2
         with:
           go-version: ${{matrix.go}}
-
       - name: checkout
         uses: actions/checkout@v2
-
       - name: tools
         run: go get golang.org/x/lint/golint
-
       - name: test
         run: make

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/dghubble/sling
 
 go 1.12
 
-require github.com/google/go-querystring v1.0.0
+require github.com/google/go-querystring v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,6 @@
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
-github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
+github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Hi, after long time using your pkg happily. I think I want to contribute back.

In this MR:

- Update go-querystring v1.1.0
- Update go v1.16 in github action