### PR TITLE
Add Method, url.Values and http.Headers

### DIFF
--- a/body.go
+++ b/body.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"net/url"
 	"strings"
 
 	goquery "github.com/google/go-querystring/query"
@@ -60,9 +61,13 @@ func (p formBodyProvider) ContentType() string {
 }
 
 func (p formBodyProvider) Body() (io.Reader, error) {
-	values, err := goquery.Values(p.payload)
-	if err != nil {
-		return nil, err
+	values, ok := p.payload.(url.Values)
+	if !ok {
+		var err error
+		values, err = goquery.Values(p.payload)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return strings.NewReader(values.Encode()), nil
 }


### PR DESCRIPTION
I'm loving the `sling` package, but have found it to be missing a handful of things for my specific use case. I tried to post an issue, but don't see a way to post issues on this repo. So, in order to facilitate discussion, here's some code to show that I'm thinking. Rather than writing up all the tests as well, I thought I'd write up the methods I'd like to see implemented and get your feedback before tackling the tests. This adds:

1. The ability to set a body form with `url.Values` in addition to using a struct and `go-query`. While I love the `goquery` mechanism, there are times, I just want to go straight to `url.Values` directly.
2. The ability to set all headers or add to all headers at once. Sometimes it's just easier to pass it all in at once
3. The ability to set the http method directly
4. The ability to add queryString parameters using `url.Values` in addition to `goquery`
5. The ability to run the final query with a `Context`

All of this enables me to have a nice `Do` method in a different API package I'm creating. Sling is the underlying client and enables me to setup defaults with authentication, etc. Sling keeps me from having to write a whole bunch of boilerplate myself, but since this client is generic, I want to give users the ability to define their own headers, queryString, etc. using the standard `http.Headers` and `url.Values`

Let me know what you think and if you have any concerns with any of the API changes. If you like what you see, I'll dig into the tests and submit this as a full PR for your review.