### PR TITLE
Allow context aware requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Slings store HTTP Request properties to simplify sending requests and decoding r
 * Encode structs into URL query parameters
 * Encode a form or JSON into the Request Body
 * Receive JSON success or failure responses
+* Control a request's lifetime via context
 
 ## Install
 
@@ -270,6 +271,29 @@ func (s *IssueService) ListByRepo(owner, repo string, params *IssueListParams) (
     return *issues, resp, err
 }
 ```
+
+### Controlling lifetime via context
+All the above functionality of a sling can be made context aware.
+
+Getting a context aware request:
+```go
+ctx, cancel := context.WithTimeout(context.Background(),10*time.Second)
+req, err := sling.New().Get("https://example.com").RequestWithContext(ctx)
+```
+Receiving in a context aware manner
+```go
+success := &struct{}{}
+failure := &struct{}{}
+ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+resp, err := sling.New().Path("https://example.com").Get("/foo").ReceiveWithContext(ctx,success,failure)
+```
+After making the request you can first check whether request completed in time before proceeding with the response:
+```go
+if errors.Is(err, context.DeadlineExceeded) {
+    // Take action accordingly
+}
+```
+For more details about effectively using context please see: https://go.dev/blog/context
 
 ## Example APIs using Sling
 

--- a/sling.go
+++ b/sling.go
@@ -1,6 +1,7 @@
 package sling
 
 import (
+	"context"
 	"encoding/base64"
 	"io"
 	"net/http"
@@ -277,6 +278,15 @@ func (s *Sling) BodyForm(bodyForm interface{}) *Sling {
 // Returns any errors parsing the rawURL, encoding query structs, encoding
 // the body, or creating the http.Request.
 func (s *Sling) Request() (*http.Request, error) {
+	return s.request(context.Background())
+}
+
+// RequestWithContext is similar to Request but allows you to pass a context.
+func (s *Sling) RequestWithContext(ctx context.Context) (*http.Request, error) {
+	return s.request(ctx)
+}
+
+func (s *Sling) request(ctx context.Context) (*http.Request, error) {
 	reqURL, err := url.Parse(s.rawURL)
 	if err != nil {
 		return nil, err
@@ -294,7 +304,7 @@ func (s *Sling) Request() (*http.Request, error) {
 			return nil, err
 		}
 	}
-	req, err := http.NewRequest(s.method, reqURL.String(), body)
+	req, err := http.NewRequestWithContext(ctx, s.method, reqURL.String(), body)
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +374,16 @@ func (s *Sling) ReceiveSuccess(successV interface{}) (*http.Response, error) {
 // the response is returned.
 // Receive is shorthand for calling Request and Do.
 func (s *Sling) Receive(successV, failureV interface{}) (*http.Response, error) {
-	req, err := s.Request()
+	return s.receive(context.Background(), successV, failureV)
+}
+
+// ReceiveWithContext is similar to Receive but allows you to pass a context.
+func (s *Sling) ReceiveWithContext(ctx context.Context, successV, failureV interface{}) (*http.Response, error) {
+	return s.receive(ctx, successV, failureV)
+}
+
+func (s *Sling) receive(ctx context.Context, successV, failureV interface{}) (*http.Response, error) {
+	req, err := s.RequestWithContext(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Here we introduce RequestWithContext() and ReceiveWithContext()
method which allow consumers to pass in a context. This is useful
for working with HTTP requests where the consumer might want
to control request lifetime via a context.