### PR TITLE
Use a centrally managed GitHub Workflow for go tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,25 +1,6 @@
 name: test
 on:
   push:
-    branches:
-      - main
-  pull_request:
 jobs:
-  build:
-    name: go
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        go: ['1.18', '1.19']
-    steps:
-      - name: setup
-        uses: actions/setup-go@v3
-        with:
-          go-version: ${{matrix.go}}
-
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: test
-        run: make
+  go:
+    uses: dghubble/.github/.github/workflows/golang-library.yaml@main

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Sling [![GoDoc](https://pkg.go.dev/badge/github.com/dghubble/sling.svg)](https://pkg.go.dev/github.com/dghubble/sling) [![Workflow](https://github.com/dghubble/sling/actions/workflows/test.yaml/badge.svg)](https://github.com/dghubble/sling/actions/workflows/test.yaml?query=branch%3Amain) [![Sponsors](https://img.shields.io/github/sponsors/dghubble?logo=github)](https://github.com/sponsors/dghubble) [![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@typhoon)
+# Sling
+[![GoDoc](https://pkg.go.dev/badge/github.com/dghubble/sling.svg)](https://pkg.go.dev/github.com/dghubble/sling)
+[![Workflow](https://github.com/dghubble/sling/actions/workflows/test.yaml/badge.svg)](https://github.com/dghubble/sling/actions/workflows/test.yaml?query=branch%3Amain)
+[![Sponsors](https://img.shields.io/github/sponsors/dghubble?logo=github)](https://github.com/sponsors/dghubble)
+[![Mastodon](https://img.shields.io/badge/follow-news-6364ff?logo=mastodon)](https://fosstodon.org/@typhoon)
 
 <img align="right" src="https://storage.googleapis.com/dghubble/small-gopher-with-sling.png">
 

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -1,6 +1,6 @@
 module github.com/dghubble/sling/examples
 
-go 1.18
+go 1.19
 
 require (
 	github.com/coreos/pkg v0.0.0-20230209195159-6f3db454fdf8

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/dghubble/sling
 
-go 1.18
+go 1.19
 
 require github.com/google/go-querystring v1.1.0


### PR DESCRIPTION
* Use GitHub Workflow from https://github.com/dghubble/.github
* Test against Go v1.19 and v1.20