### PR TITLE
 Allow Go test Workflow to run on PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,11 @@
 name: test
 on:
   push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 jobs:
   go:
     uses: dghubble/.github/.github/workflows/golang-library.yaml@main


### PR DESCRIPTION
* When GitHub Workflows were refactored to draw from a central repo, the pull_request trigger was lost
* Allow the go test/library workflow to be run on PRs from the general public, it doesn't make use of any sensitive materials (but it does count against minutes)