### PR TITLE
Add response data streaming facility

### DIFF
--- a/response.go
+++ b/response.go
@@ -2,6 +2,8 @@ package sling
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 )
 
@@ -12,11 +14,36 @@ type ResponseDecoder interface {
 }
 
 // jsonDecoder decodes http response JSON into a JSON-tagged struct value.
-type jsonDecoder struct {
-}
+type jsonDecoder struct{}
 
 // Decode decodes the Response Body into the value pointed to by v.
 // Caller must provide a non-nil v and close the resp.Body.
 func (d jsonDecoder) Decode(resp *http.Response, v interface{}) error {
 	return json.NewDecoder(resp.Body).Decode(v)
+}
+
+// ByteStreamer is a [sling.ResponseDecoder] which simply forwards response data 'as is' rather than trying to deocde
+// it. This is useful when 1/ response is actually just plain text (like 5XX response from API gateways). 2/ response
+// data is a byte stream representing some file or a binary blob.
+//
+// It leverages existing facilities of automatic discarding and closing of response body so the user does not need to
+// care about it.
+type ByteStreamer struct{}
+
+// Decode simply tries to copy response data into v assuming its an [io.Writer] instance. Assuming so little about v
+// gives consumers a lot of choice about consuming response data. They can wait for all data to be dumped into some
+// buffer then act on it or they can read as soon as data gets written.
+func (d ByteStreamer) Decode(resp *http.Response, v any) error {
+	var w io.Writer
+	w, ok := v.(io.Writer)
+	if !ok {
+		return fmt.Errorf("expected type: %T; got: %T", w, v)
+	}
+
+	_, err := io.Copy(w, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed copying response data to v: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Here we add a new ResponseDecoder: ByteStreamer. This allows user to get a stream of bytes 'as is' i.e. without any decoding. This is useful for all those streaming use cases like downloading files, binary blobs etc.

This is also useful when response data is just plain text for e.g. the 5XX responses from API gateways.

Side changes:
- The xml stuff in testing code no longer needed as this new decoder is used as non-default decoder.

- Code reformatting as per gopls/gofumpt style.