### PR TITLE
New Extend API for intuitively extending URL path

### DIFF
--- a/sling.go
+++ b/sling.go
@@ -204,7 +204,15 @@ func (s *Sling) Path(path string) *Sling {
 	pathURL, pathErr := url.Parse(path)
 	if baseErr == nil && pathErr == nil {
 		s.rawURL = baseURL.ResolveReference(pathURL).String()
-		return s
+	}
+	return s
+}
+
+// Extend simply extends the rawURL by appending path to it using [url.JoinPath].
+// If parsing error occurs, the rawURL is left unmodified.
+func (s *Sling) Extend(path string) *Sling {
+	if u, err := url.JoinPath(s.rawURL, path); err == nil {
+		s.rawURL = u
 	}
 	return s
 }


### PR DESCRIPTION
Currently to extend current rawURL we have to use Path() API which is okay but comes with some nuances:
- Current rawURL must end in `/` to be extensible.
- The new path should end in `/` to be further extensible. Plus it is not easy to create an intuitive looking api like this where each step appends a new path:

// Get one student
client.Students().Student("id").Get() // GET http://server/students/id

// Update one student
client.Students().Student("id").Update(...) // POST http://server/students/id

// Get all students
client.Students().Get() // GET http://server/students

If we use Path() API then `Students()` method cannot simply append `/students` to rawURL because we want the new URL to be further extendible by `Student("id")` method. On the other hand if we try to add `students/ ` in Students() then first two calls will work but now last call wont work because the rawURL for that call would be: `http://server/students/`.

The new Extend API solves this problem and makes it very intitive and no brainer for appending/extending URL paths.