### PR TITLE
feat: add Headers method to set multiple headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,20 @@ req, err := sling.New().Post("http://upload.com/gophers")
 
 ### Headers
 
-`Add` or `Set` headers for requests created by a Sling.
+Use the `Add`, `Set`, or `Headers` methods to manage request headers.
 
 ```go
 s := sling.New().Base(baseUrl).Set("User-Agent", "Gophergram API Client")
 req, err := s.New().Get("gophergram/list").Request()
+```
+
+```go
+headers := map[string]interface{}{
+    "Content-Type": "application/json",
+    "Accept":       []string{"application/json", "text/html"},
+}
+
+req, err := sling.New().Base(baseUrl).Headers(headers).Get("gophergram/list").Request()
 ```
 
 ### Query

--- a/sling.go
+++ b/sling.go
@@ -181,6 +181,46 @@ func (s *Sling) SetBasicAuth(username, password string) *Sling {
 	return s.Set("Authorization", "Basic "+basicAuth(username, password))
 }
 
+// Headers sets the headers for the Sling object.
+//
+// This function accepts a map of headers, where the key is a string (header name),
+// and the value can either be a string (a single header value) or a slice of strings (multiple values for a single header).
+// Based on the type of the value, it calls the appropriate methods:
+// - If the value is a string, it uses the `Set` method to set the header.
+// - If the value is a slice of strings, it uses the `Add` method to add multiple values for the same header.
+//
+// Example usage:
+//
+// // Declare the headers map separately
+//
+//	headers := map[string]interface{}{
+//	    "Content-Type": "application/json",
+//	    "Accept":       []string{"application/json", "text/html"},
+//	}
+//
+// // Pass the map to the Headers function
+// req, err := sling.New().Get("https://example.com").Headers(headers).Request()
+// client.Do(req)
+//
+// After calling the above code:
+// - The "Content-Type" header will be set to "application/json"
+// - The "Accept" header will have two values: "application/json" and "text/html"
+//
+// If the value for a header has an unsupported type, the message "Unknown type" will be printed.
+func (s *Sling) Headers(headers map[string]interface{}) *Sling {
+	for key, value := range headers {
+		switch v := value.(type) {
+		case string:
+			s.Set(key, v)
+		case []string:
+			for _, _v := range v {
+				s.Add(key, _v)
+			}
+		}
+	}
+	return s
+}
+
 // basicAuth returns the base64 encoded username:password for basic auth copied
 // from net/http.
 func basicAuth(username, password string) string {

--- a/sling_test.go
+++ b/sling_test.go
@@ -963,6 +963,29 @@ func TestReuseTcpConnections(t *testing.T) {
 	}
 }
 
+func TestHeaders(t *testing.T) {
+	s := New()
+	headers := map[string]interface{}{
+		"Content-Type":  "application/json",
+		"X-Custom-List": []string{"value1", "value2"},
+	}
+
+	s.Headers(headers)
+
+	req, _ := s.Request()
+	if req != nil {
+		if req.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("Expected Content-Type to be application/json, got %s", req.Header.Get("Content-Type"))
+		}
+		values := req.Header.Values("X-Custom-List")
+		if len(values) != 2 || values[0] != "value1" || values[1] != "value2" {
+			t.Errorf("Expected X-Custom-List to be [value1 value2], got %v", values)
+		}
+	} else {
+		t.Errorf("Expected non-nil request")
+	}
+}
+
 // Testing Utils
 
 // testServer returns an http Client, ServeMux, and Server. The client proxies


### PR DESCRIPTION
### Summary  
Added a new `Headers` method to allow setting multiple headers at once. This method supports both single values (string) and multiple values ([]string) for headers, making it more convenient than calling `Set` or `Add` separately.

### Changes  
- Implemented `Headers(headers map[string]interface{}) *Sling` method.  
- Supports string values (uses `Set`) and string slices (uses `Add`).  
- Logs an error message for unsupported types.  

### Why?  
Previously, users had to call `Set` and `Add` multiple times to configure headers. With `Headers`, they can now provide all headers in a single call, improving code readability and usability.

### Example usage:  
```go
s := sling.New().Base(baseUrl).Headers(map[string]interface{}{
    "Content-Type": "application/json",
    "Accept":       []string{"application/json", "text/html"},
})
